### PR TITLE
Fix the language picker so it's not hard coded to www.freebsd.org

### DIFF
--- a/website/themes/beastie/layouts/_partials/site-header.html
+++ b/website/themes/beastie/layouts/_partials/site-header.html
@@ -185,7 +185,7 @@
               <a href="{{ "support/webresources" | relLangURL }}">{{ i18n "h-webresources" }}</a>
             </li>
           </ul>
-        </li>          
+        </li>
       </ul>
     </nav>
     <div class="search-donate-container">
@@ -221,15 +221,11 @@
         </summary>
         <ul class="lang-dropdown">
           <li>
-            <a href="{{ .Permalink }}" lang="{{ .Language.Lang }}" class="current-lang" aria-current="page">
-              {{ .Language.LanguageName }}
-            </a>
+            <a href="{{ .Language.Lang | relLangURL }}" class="current-lang" aria-current="page">{{ .Language.LanguageName }}</a>
           </li>
           {{ range .Translations }}
             <li>
-              <a href="{{ .Permalink }}" lang="{{ .Language.Lang }}">
-                {{ .Language.LanguageName }}
-              </a>
+              <a href="{{ .Language.Lang | relURL }}" lang="{{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
             </li>
           {{ end }}
         </ul>


### PR DESCRIPTION
Similar story to other URL fixes. When deployed to the test site 'www.freebsd.org' is hard coded to the language picker, which of course breaks. This makes the URLs relative.