### PR TITLE
Reduce downloads on home

### DIFF
--- a/website/themes/beastie/layouts/_partials/site-header.html
+++ b/website/themes/beastie/layouts/_partials/site-header.html
@@ -185,7 +185,7 @@
               <a href="{{ "support/webresources" | relLangURL }}">{{ i18n "h-webresources" }}</a>
             </li>
           </ul>
-        </li>          
+        </li>
       </ul>
     </nav>
     <div class="search-donate-container">
@@ -221,15 +221,11 @@
         </summary>
         <ul class="lang-dropdown">
           <li>
-            <a href="{{ .Permalink }}" lang="{{ .Language.Lang }}" class="current-lang" aria-current="page">
-              {{ .Language.LanguageName }}
-            </a>
+            <a href="{{ .Language.Lang | relLangURL }}" class="current-lang" aria-current="page">{{ .Language.LanguageName }}</a>
           </li>
           {{ range .Translations }}
             <li>
-              <a href="{{ .Permalink }}" lang="{{ .Language.Lang }}">
-                {{ .Language.LanguageName }}
-              </a>
+              <a href="{{ .Language.Lang | relURL }}" lang="{{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
             </li>
           {{ end }}
         </ul>

--- a/website/themes/beastie/layouts/home.html
+++ b/website/themes/beastie/layouts/home.html
@@ -19,18 +19,6 @@
           </div>
         </section>
         <section class="downloads download-section">
-          <div class="download-section-title">{{ i18n "download-freebsd" }} {{ index hugo.Data.releases "rel144-current" }}</div>
-          <div>
-            <a class="download-button-release" href="https://download.freebsd.org/releases/amd64/amd64/ISO-IMAGES/{{ index hugo.Data.releases "rel144-current" }}/">amd64</a>
-            <a class="download-button-release" href="https://download.freebsd.org/releases/arm64/aarch64/ISO-IMAGES/{{ index hugo.Data.releases "rel144-current" }}/">aarch64</a>
-            <a class="download-button-release" href="/where/#download">{{ i18n "other" }}</a>
-          </div>
-          <div class="download-links">
-            <a href="/releases/{{ index hugo.Data.releases "rel144-current" }}R/announce/">{{ i18n "announcement" }}</a>,
-            <a href="/releases/{{ index hugo.Data.releases "rel144-current" }}R/relnotes/">{{ i18n "notes" }}</a>
-          </div>
-        </section>
-        <section class="downloads download-section">
           <div class="download-section-title">{{- i18n "upcoming-releases" -}}</div>
           <div class="additional-downloads">
             {{ $betaUpcoming := index hugo.Data.releases "beta-upcoming" }}

--- a/website/themes/beastie/layouts/home.html
+++ b/website/themes/beastie/layouts/home.html
@@ -18,28 +18,6 @@
             <a href="/releases/{{ index hugo.Data.releases "rel150-current" }}R/relnotes/">{{ i18n "notes" }}</a>
           </div>
         </section>
-        <section class="downloads download-section">
-          <div class="download-section-title">{{- i18n "upcoming-releases" -}}</div>
-          <div class="additional-downloads">
-            {{ $betaUpcoming := index hugo.Data.releases "beta-upcoming" }}
-            {{ if ne $betaUpcoming "IGNORE" }}
-              <a class="download-button-release" href={{ index hugo.Data.releases "u-betarel-schedule" }}>{{ index hugo.Data.releases "betarel-current" }}</a>
-            {{ end }}
-            {{ $beta2Upcoming := index hugo.Data.releases "beta2-upcoming" }}
-            {{ if ne $beta2Upcoming "IGNORE" }}
-              <a class="download-button-release" href={{ index hugo.Data.releases "u-betarel2-schedule" }}>{{ index hugo.Data.releases "betarel2-current" }}</a>
-            {{ end }}
-            {{ $beta3Upcoming := index hugo.Data.releases "beta3-upcoming" }}
-            {{ if ne $beta3Upcoming "IGNORE" }}
-              <a class="download-button-release" href={{ index hugo.Data.releases "u-betarel3-schedule" }}>{{ index hugo.Data.releases "betarel3-current" }}</a>
-            {{ end }}
-            <!--{{ index hugo.Data.releases "rel151-current" }}: <a href="/releases/{{ index hugo.Data.releases "rel151-current" }}R/schedule/">2025-12</a> -
-            {{ index hugo.Data.releases "rel144-current" }}: <a href="/releases/{{ index hugo.Data.releases "rel144-current" }}R/schedule/">2026-03</a>-->
-          </div>
-          <div>
-            <a href="/where/#download-snapshots">{{- i18n "development-snapshots" -}}</a>
-          </div>
-        </section>
       </section>
     </section>
   </section>


### PR DESCRIPTION
You can choose what to do with this one Sergio, it's not so much a fix as a proposal. We really shouldn't have three version CTAs on the front page — thinking of new users, it's confusing. "_Which version do I pick and why?_" 

We should have one, clear, download option on the homepage, and that's it. K I S S 😄  If users want to explore older or upcoming versions, they can find them on the 'Get FreeBSD' page.